### PR TITLE
Fixed issues that arise from breaking changes

### DIFF
--- a/gamezone/App.js
+++ b/gamezone/App.js
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import Home from './screens/home';
 import * as Font from 'expo-font';
-import { AppLoading } from 'expo';
+import  AppLoading  from 'expo-app-loading';
 
-const getFonts = () => Font.loadAsync({
+const getFonts = async() => await Font.loadAsync({
   'nunito-regular': require('./assets/fonts/Nunito-Regular.ttf'),
   'nunito-bold': require('./assets/fonts/Nunito-Bold.ttf'),
 });
@@ -19,7 +19,9 @@ export default function App() {
     return (
       <AppLoading 
         startAsync={getFonts} 
+        onError={console.warn}
         onFinish={() => setFontsLoaded(true)} 
+       
       />
     )
   }


### PR DESCRIPTION
AppLoading is no longer found in expo and you first need to install it by `expo install expo-app-loading` as it is no longer included,
Some changes in how promises are handled either by node.js or the AppLoading component

I just want to say these errors really created issues for me(everything broke)and I had to solve it myself, so I am doing this to save anyone this frustration in the future